### PR TITLE
Fix registration bug

### DIFF
--- a/utils.php
+++ b/utils.php
@@ -54,7 +54,7 @@ function register($E){
     if($E['course_required']){
         $studiengang = filter_input(INPUT_POST, 'studiengang', FILTER_SANITIZE_ENCODED);
         $abschluss = filter_input(INPUT_POST, 'abschluss', FILTER_SANITIZE_ENCODED);
-        $semester =filter_input(INPUT_POST, 'semester', FILTER_SANITIZE_NUMBER_INT);
+        $semester =filter_input(INPUT_POST, 'semester', FILTER_SANITIZE_ENCODED);
     }
     if($E['food'])
         $essen = filter_input(INPUT_POST, 'essen', FILTER_SANITIZE_ENCODED);
@@ -166,7 +166,7 @@ function showRegistration($E){
                 <label><input type="radio" class="form-semester" name="semester" value="1" required> 1</label> <br>
                 <label><input type="radio" class="form-semester" name="semester" value="2"> 2</label> <br>
                 <label><input type="radio" class="form-semester" name="semester" value="3"> 3</label> <br>
-                <label><input type="radio" class="form-semester" name="semester" value="0"> viele <label/><br>'
+                <label><input type="radio" class="form-semester" name="semester" value="viele"> viele <label/><br>'
         : '';
         echo ($E['food']) ?
                 '<br>Essen:<br>


### PR DESCRIPTION
Sanitization of $semester with value "0" results in an Error. Replaced "0" with "viele"...

`FILTER_SANITIZE_NUMBER_INT` behaves not as described. `"0"` is a numerical digit and still gets removed.
`FILTER_SANITIZE_ENCODED` uses `FILTER_FLAG_STRIP_LOW` that _"Strips characters that have a numerical value <32."_

I changed the value to `"viele"` to get this value in the csv as well instead of `"0"`