### PR TITLE
fix ics export

### DIFF
--- a/calender.php
+++ b/calender.php
@@ -84,7 +84,7 @@ if (isset($_GET['e']) && isset($_GET['ics'])) {
 
 	if ($ics !== '') {
 		header('Content-Type: ' . ICS_MIME_TYPE);
-		header('Content-Disposition: attachment; filename="' . $E['name'] . '.ics"');
+		header('Content-Disposition: attachment; filename="' . $E->name . '.ics"');
 		echo $ics;
 	}
 }


### PR DESCRIPTION
When I clicked the download button on the website I got a file `calendar.ics` with the following error content:
```html
<br />
<b>Fatal error</b>:  Uncaught Error: Cannot use object of type Event as array in /var/www/html/calender.php:87
Stack trace:
#0 {main}
  thrown in <b>/var/www/html/calender.php</b> on line <b>87</b><br />
```