### PR TITLE
Adapt schema check to fit default values in README

### DIFF
--- a/check_yml_integrity.py
+++ b/check_yml_integrity.py
@@ -90,6 +90,11 @@ REQUIRED_SCHEMA = Schema(
             "end": And(str, is_date),
         },
         "csv_path": And(str, len, lambda s: is_unique("csv_path", s)),
+        Optional("form"): {
+            Optional("breakfast"): bool,
+            Optional("food"): bool,
+            Optional("course_required"): bool
+        },
         "icon": And(str, is_icon),
         Optional("metas"): [str],
     }


### PR DESCRIPTION
The YAML checker had some values missing, some of which were used in the event for 'Erstihuette'.