### PR TITLE
TermineSoSe25 - Update

### DIFF
--- a/config.php
+++ b/config.php
@@ -7,6 +7,6 @@ $FILE_REVISION = "?v=" . file_get_contents(__DIR__ . "/.git/refs/heads/master", 
 
 # General Information
 $CONFIG_CONTACT = 'fsi@fsi.uni-tuebingen.de';
-$CONFIG_TERM = 'WS 24/25'; # example: WS 19/20 or SS 20
+$CONFIG_TERM = 'SoSe 25'; # example: WS 19/20 or SS 20
 // see https://www.php.net/manual/en/language.constants.predefined.php
 $fp = realpath(__DIR__ . "/../eei-registration/") . "/"; #File Prefix

--- a/events.yml
+++ b/events.yml
@@ -120,7 +120,7 @@ events:
   SPx:
     name: "Spieleabend 2"
     text: i18n:spx_text
-    location: "Sand 14, A104"
+    location: "Sand 14, A302"
     max_participants: 200
     event_date:
       start: "16.04.2025 19:00"
@@ -173,11 +173,11 @@ events:
     location: "Terrasse Sand"
     max_participants: 150
     event_date:
-      start: "25.04.2024 18:30"
+      start: "25.04.2025 18:30"
       onTime: false
     registration_date:
       start: "18.04.2025 00:00"
-      end: "25.10.2024 17:00"
+      end: "25.04.2025 17:00"
     csv_path: "ersti-grillen2.csv"
     icon: "grill"
     dinos: True

--- a/events.yml
+++ b/events.yml
@@ -47,7 +47,7 @@ events:
       start: "04.04.2025 00:00"
       end: "10.04.2025 23:59"
     csv_path: "ersti-fruehstueck.csv"
-    icon: "signs"
+    icon: "food"
     metas:
       - "seb"
       - "clara"


### PR DESCRIPTION
Icon for "Frühstück" wasn't displayed, change dit to "food". Better match anyways.

Term needed to be changed in `config.php`.

Also needed to fix the date of "Grillen2" and location of "Spieleabend".