### PR TITLE
CalDAV/ICS live feed

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -29,6 +29,23 @@ class ICSGenerator
             'CALSCALE:GREGORIAN',
             'METHOD:PUBLISH',
             implode(self::LINE_ENDING, $eventBlocks),
+            'BEGIN:VTIMEZONE',
+            'TZID:Europe/Berlin',
+            'BEGIN:DAYLIGHT',
+            'TZOFFSETFROM:+0100',
+            'TZOFFSETTO:+0200',
+            'TZNAME:CEST',
+            'DTSTART:19700329T020000',
+            'RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU',
+            'END:DAYLIGHT',
+            'BEGIN:STANDARD',
+            'TZOFFSETFROM:+0200',
+            'TZOFFSETTO:+0100',
+            'TZNAME:CET',
+            'DTSTART:19701025T030000',
+            'RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU',
+            'END:STANDARD',
+            'END:VTIMEZONE',
             'END:VCALENDAR'
         ]);
     }
@@ -39,7 +56,7 @@ class ICSGenerator
 			'BEGIN:VEVENT',
 			'UID:' . $this->generateUID($event),
 			'DTSTAMP:' . $this->formatDateTime(new DateTimeImmutable()),
-			'DTSTART:' . $this->formatDateTime((new DateTimeImmutable())->setTimestamp($event->getEventStartUTS())),
+			'DTSTART;TZID=Europe/Berlin:' . $this->formatDateTime((new DateTimeImmutable())->setTimestamp($event->getEventStartUTS())),
 		];
 		
 		$eventStartUTS = $event->getEventStartUTS();
@@ -47,12 +64,12 @@ class ICSGenerator
 		
 		// Check if the event has an end
 		if ($eventEndUTS > 0) {
-			$eventData[] = 'DTEND:' . $this->formatDateTime((new DateTimeImmutable())->setTimestamp($eventEndUTS));
+			$eventData[] = 'DTEND;TZID=Europe/Berlin:' . $this->formatDateTime((new DateTimeImmutable())->setTimestamp($eventEndUTS));
 		} else {
 			// If there is no end, instead of using the 0 (which is kind of bad because this represents 1970-01-01)
 			// we set the end to the end of the day
-			$endOfDay = (new DateTimeImmutable())->setTimestamp($eventStartUTS)->setTime(23, 59, 59);
-			$eventData[] = 'DTEND:' . $this->formatDateTime($endOfDay);
+			$endOfDay = (new DateTimeImmutable())->setTimestamp($eventStartUTS)->setTime(23, 59, 00);
+			$eventData[] = 'DTEND;TZID=Europe/Berlin:' . $this->formatDateTime($endOfDay);
 		}
 		
 		$eventData[] = 'SUMMARY:' . $this->escapeString($event->name);
@@ -91,7 +108,7 @@ class ICSGenerator
     
     private function formatDateTime(DateTimeInterface $dateTime): string
     {
-        return $dateTime->format('Ymd\THis\Z');
+        return $dateTime->format('Ymd\THis');
     }
     
     private function escapeString(string $text): string

--- a/css/modal.css
+++ b/css/modal.css
@@ -1,0 +1,41 @@
+/* Styles for Calendar Link Modal Box */
+/* Code Base: https://www.w3schools.com/howto/howto_css_modals.asp */
+.modal {
+    /* modal background div */
+    display: none;
+    position: fixed;
+    z-index: 1;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgb(0, 0, 0);
+    background-color: rgba(0, 0, 0, 0.4);
+}
+
+.modal-content {
+    /* modal content box */
+    background-color: var(--background-color-light);
+    color: var(--primary-color);
+    margin: 15% auto;
+    text-align: center;
+    padding: 20px;
+    border: 1px solid var(--border);
+    width: 80%;
+    border-radius: var(--pill-border-radius);
+}
+
+.close {
+    /* close button in modal box */
+    color: var(--primary-color);
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+}
+.close:hover,
+.close:focus {
+    color: black;
+    text-decoration: none;
+    cursor: pointer;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -60,8 +60,11 @@ body {
     box-sizing: border-box;
 }
 
-*, *:before, *:after {
-    box-sizing: inherit; /* Ensure padding doesn't increase width */
+*,
+*:before,
+*:after {
+    box-sizing: inherit;
+    /* Ensure padding doesn't increase width */
 }
 
 main {
@@ -269,7 +272,8 @@ a .link:hover {
 }
 
 
-h1, .title {
+h1,
+.title {
     font-size: clamp(1.8em, 5vw, 3.5em);
     word-wrap: break-word;
     text-align: center;
@@ -293,7 +297,8 @@ h1, .title {
 }
 
 
-input[type="submit"] {
+input[type="submit"],
+input[type="button"] {
     text-align: center;
     padding: 10px 20px;
     cursor: pointer;
@@ -311,13 +316,15 @@ input[type="submit"] {
     display: inline-block;
 }
 
-input[type="submit"]:hover {
+input[type="submit"]:hover,
+input[type="button"]:hover {
     background-color: rgba(255, 255, 255, 0.3);
     box-shadow: var(--box-shadow-hover);
     transform: none;
 }
 
-input[type="submit"]:disabled {
+input[type="submit"]:disabled,
+input[type="button"]:disabled {
     background-color: #aaaaaa;
     border-color: #888888;
     color: #dddddd;
@@ -333,7 +340,8 @@ form {
     text-align: left;
 }
 
-form input[type="submit"], form .text-block {
+form input[type="submit"],
+form .text-block {
     margin: 0 auto 10px;
     display: block;
     text-align: center;
@@ -496,3 +504,4 @@ form input[type="submit"], form .text-block {
     border-color: var(--primary-color);
     box-shadow: var(--box-shadow);
 }
+

--- a/head.php
+++ b/head.php
@@ -14,5 +14,6 @@ global $i18n, $FILE_REVISION;
     <link rel='stylesheet' href="css/style.css<?= $FILE_REVISION ?>">
     <link rel='stylesheet' href="css/icons.css<?= $FILE_REVISION ?>">
     <link rel='stylesheet' href="css/input.css<?= $FILE_REVISION ?>">
+    <link rel='stylesheet' href="css/modal.css<?= $FILE_REVISION ?>">
     <title><?= $i18n['title'] ?></title>
 </head>

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -9,6 +9,7 @@
   "time_takingPlace": "Jetzt",
   "calendar_download": "Kalender herunterladen",
   "calendar_subscribe": "Kalender abonnieren",
+  "calendar_subscribe_text": "Link zum Import in eine Kalender-Software:",
   "back": "Zurück zur Übersicht",
   "form_yourName": "Dein Name (Vor- und Nachname)",
   "form_email": "Mail-Adresse",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -9,6 +9,7 @@
   "time_takingPlace": "Taking place",
   "calendar_download": "Download calendar",
   "calendar_subscribe": "Subscribe to calendar",
+  "calendar_subscribe_text": "Link to import in your calendar software:",
   "back": "Back to overview",
   "form_yourName": "Your name (first and last name)",
   "form_email": "Mail address",

--- a/index.php
+++ b/index.php
@@ -88,6 +88,12 @@ require_once 'head.php';
                 <input id="btn-clr" type="submit" value="<?= $i18n['delete'] ?>"
                        onclick="if(confirm('<?= addslashes($i18n['index_confirmDelete']) ?>')) { localStorage.clear(); alert('<?= addslashes($i18n['index_deletedData']) ?>'); }">
 
+                <a href="calendar.php?allevents">
+                    <span class="link">
+                        iCal-Feed aller Events
+                    </span>
+                </a>
+
                 <a href="https://github.com/fsi-tue/eei">
                     <!-- Removed inner div, styling applied directly to link -->
                     <span class="link"> <!-- Use span or div if needed, styled by .link -->

--- a/index.php
+++ b/index.php
@@ -88,11 +88,8 @@ require_once 'head.php';
                 <input id="btn-clr" type="submit" value="<?= $i18n['delete'] ?>"
                        onclick="if(confirm('<?= addslashes($i18n['index_confirmDelete']) ?>')) { localStorage.clear(); alert('<?= addslashes($i18n['index_deletedData']) ?>'); }">
 
-                <a href="calendar.php?allevents">
-                    <span class="link">
-                        iCal-Feed aller Events
-                    </span>
-                </a>
+
+                <input class="link" id="calendar-subscription-button" type="button" value="<?=$i18n['calendar_subscribe']?>">
 
                 <a href="https://github.com/fsi-tue/eei">
                     <!-- Removed inner div, styling applied directly to link -->
@@ -101,6 +98,15 @@ require_once 'head.php';
                     </span>
                 </a>
             </div>
+        </div>
+    </div>
+    <!-- Hidden Modal for Calendar Subscription -->
+    <div id="calendar-subscription-modal" class="modal">
+        <div class="modal-content">
+            <span class="close">&times;</span>
+            <label for="calendar-link"><?=$i18n['calendar_subscribe_text']?><br>
+            <input type="text" id="calendar-link" name="calendar-link" value="https://eei.fsi.uni-tuebingen.de/calendar.php?allevents" readonly>
+        </label>
         </div>
     </div>
 </main>
@@ -114,6 +120,7 @@ require_once 'head.php';
         location.href = `${baseUrl}?lang=${this.value}`;
     });
 </script>
+<script src="js/calendarModal.js"></script>
 </body>
 
 </html>

--- a/js/calendarModal.js
+++ b/js/calendarModal.js
@@ -1,0 +1,25 @@
+// Get the modal
+var modal = document.getElementById("calendar-subscription-modal");
+
+// Get the button that opens the modal
+var btn = document.getElementById("calendar-subscription-button");
+
+// Get the <span> element that closes the modal
+var span = document.getElementsByClassName("close")[0];
+
+// When the user clicks on the button, open the modal
+btn.onclick = function() {
+  modal.style.display = "block";
+}
+
+// When the user clicks on <span> (x), close the modal
+span.onclick = function() {
+  modal.style.display = "none";
+}
+
+// When the user clicks anywhere outside of the modal, close it
+window.onclick = function(event) {
+  if (event.target == modal) {
+    modal.style.display = "none";
+  }
+}


### PR DESCRIPTION
This PR addresses issue #120.

This patch modifies the existing ICS export feature to allow calendar programs to subscribe to all EEI events via a URL. The subscription link will be:
https://eei.fsi.uni-tuebingen.de/calendar.php?allevents

It should be possible to subscribe to this URL from our Nextcloud instance, and hopefully also via the calendar plugin on our website.
I tested it with Nextcloud, Apple Calendar, and Google Calendar. These applications seem to update event changes from the EEI calendar almost in real-time.

Additionally, I fixed a timezone issue — all event times are now exported in German local time (Europe/Berlin, not Büsingen 😄).

@am9zZWY @PhictionalOne 
