### PR TITLE
Fix calendar export to exclude cancelled events

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -20,6 +20,9 @@ class ICSGenerator
     {
         $eventBlocks = array();
         foreach($this->events as $event) {
+            if ($event->cancelled) {
+                continue;
+            }
             $eventBlocks[] = $this->generateEventBlock($event);
         }
         return implode(self::LINE_ENDING, [


### PR DESCRIPTION
Do not include cancelled events in `allevents` export. Although we might one to rename that option.