### PR TITLE
Feature: Filterable Event Categories (addresses #267)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,110 +83,159 @@ Usage of the `events.yml` file:
 Full Example:
 
 ```yaml
-# Dummy event
-# Instead of SP1, use a unique identifier for the event, e.g. WD1 for Wanderung 1 or SP2 for Spieleabend 2.
-SP1:
-  # Name of the event.
-  # Not required!
-  # IMPORTANT: If not set, it will look up the name in the i18n files.
-  name: "Spieleabend"
+events:
+  # Dummy event
+  # Instead of SP1, use a unique identifier for the event, e.g. WD1 for Wanderung 1 or SP2 for Spieleabend 2.
+  SP1:
+    # Name of the event.
+    # Not required!
+    # IMPORTANT: If not set, it will look up the name in the i18n files.
+    name: "Spieleabend"
 
-  # Boolean value indicating if the event was cancelled.
-  # Not required!
-  # IMPORTANT: If not set, it will be set to false.
-  cancelled: false
+    # Boolean value indicating if the event was cancelled.
+    # Not required!
+    # IMPORTANT: If not set, it will be set to false.
+    cancelled: false
 
-  # Text of the event
-  # Not required!
-  # IMPORTANT: If not set, it will look up the description in the i18n files.
-  # You can use HTML tags in the text.
-  # Example: "Ein <strong>gemütlicher Abend</strong> mit Spielen und Getränken."
-  text: "Ein gemütlicher Abend mit Spielen und Getränken."
+    # Text of the event
+    # Not required!
+    # IMPORTANT: If not set, it will look up the description in the i18n files.
+    # You can use HTML tags in the text.
+    # Example: "Ein <strong>gemütlicher Abend</strong> mit Spielen und Getränken."
+    text: "Ein gemütlicher Abend mit Spielen und Getränken."
 
-  # Additional information about the event.
-  # Not required!
-  # IMPORTANT: If not set, it will look up the info in the i18n files.
-  info: "Für die Veranstaltung gilt 3G."
+    # Additional information about the event.
+    # Not required!
+    # IMPORTANT: If not set, it will look up the info in the i18n files.
+    info: "Für die Veranstaltung gilt 3G."
 
-  # Location where the event will take place. Can be a specific address or a general area description.
-  location: "Sand 14, A301"
+    # Location where the event will take place. Can be a specific address or a general area description.
+    location: "Sand 14, A301"
 
-  # Optional map links for the location
-  # Not required!
-  # Allows users to get directions to the event location via different map providers.
-  # Only "google" and "osm" keys are allowed.
-  location_maps:
-    google: "https://www.google.com/maps/search/?api=1&query=Sand+14+T%C3%BCbingen"
-    osm: "https://www.openstreetmap.org/search?query=Sand%2014%2C%20T%C3%BCbingen"
+    # Optional map links for the location
+    # Not required!
+    # Allows users to get directions to the event location via different map providers.
+    # Only "google" and "osm" keys are allowed.
+    location_maps:
+      google: "https://www.google.com/maps/search/?api=1&query=Sand+14+T%C3%BCbingen"
+      osm: "https://www.openstreetmap.org/search?query=Sand%2014%2C%20T%C3%BCbingen"
 
-  # Boolean value indicating if the event offers a registration.
-  # Not required, default value is true
-  # Set this to false for pure informational entries like a Clubhausfest
-  registration_enabled: true
+    # Boolean value indicating if the event offers a registration.
+    # Not required, default value is true
+    # Set this to false for pure informational entries like a Clubhausfest
+    registration_enabled: true
 
-  # Maximum number of participants that can attend the event.
-  max_participants: 120
+    # Maximum number of participants that can attend the event.
+    max_participants: 120
 
-  # Boolean value indicating if the event is open for past members.
-  # Not required!
-  # IMPORTANT: If not set, it will be set to false.
-  dinos: false
+    # Boolean value indicating if the event is open for past members.
+    # Not required!
+    # IMPORTANT: If not set, it will be set to false.
+    dinos: false
 
 
-  # Event timing details.
-  event_date:
-    # Start date and time of the event, formatted as DD.MM.YYYY HH:MM.
-    start: "12.04.2024 20:00"
+    # Event timing details.
+    event_date:
+      # Start date and time of the event, formatted as DD.MM.YYYY HH:MM.
+      start: "12.04.2024 20:00"
 
-    # End date and time of the event, formatted as DD.MM.YYYY HH:MM.
-    # Not required
-    end: "12.04.2024 23:00"
+      # End date and time of the event, formatted as DD.MM.YYYY HH:MM.
+      # Not required
+      end: "12.04.2024 23:00"
 
-    # Boolean value indicating if the event is expected to start exactly on time.
-    onTime: true
+      # Boolean value indicating if the event is expected to start exactly on time.
+      onTime: true
 
-  # Registration period for the event.
-  registration_date:
-    # Start date and time for registration, formatted as DD.MM.YYYY HH:MM.
-    # Not required
-    start: "27.03.2024 00:00"
-    # End date and time for registration, ensuring it ends before the event starts.
-    end: "12.04.2024 19:00"
+    # Registration period for the event.
+    registration_date:
+      # Start date and time for registration, formatted as DD.MM.YYYY HH:MM.
+      # Not required
+      start: "27.03.2024 00:00"
+      # End date and time for registration, ensuring it ends before the event starts.
+      end: "12.04.2024 19:00"
 
-  # Additional information required for the event registration
-  # Isn't required! Below are the default values.
-  form:
-    # Ask for breakfast preferences
-    # By default, this is set to false
-    breakfast: false
-    # Ask for food preferences
-    # By default, this is set to false
-    food: false
-    # Ask for gender
-    # By default, this is set to false
-    gender: false    
-    # Ask for course information
-    # By default, this is set to true
-    course_required: true
-    # Ask if the participant drinks alcohol
-    # This is set to false by default
-    no_alcohol: false
+    # Additional information required for the event registration
+    # Isn't required! Below are the default values.
+    form:
+      # Ask for breakfast preferences
+      # By default, this is set to false
+      breakfast: false
+      # Ask for food preferences
+      # By default, this is set to false
+      food: false
+      # Ask for gender
+      # By default, this is set to false
+      gender: false    
+      # Ask for course information
+      # By default, this is set to true
+      course_required: true
+      # Ask if the participant drinks alcohol
+      # This is set to false by default
+      no_alcohol: false
 
-    # Path to the CSV file associated with the event. Include the file extension.
-    csv_path: "ersti-kneipentour1.csv"
+      # Path to the CSV file associated with the event. Include the file extension.
+      csv_path: "ersti-kneipentour1.csv"
 
-    # Icon representing the event, used in UI elements. Should match a file name or identifier.
-    # Available icons: beer, cap, clock, cocktail, dice, film, food, grill, hiking, home, marker, route, sings
-    icon: "route"
+      # Icon representing the event, used in UI elements. Should match a file name or identifier.
+      # Available icons: beer, cap, clock, cocktail, dice, film, food, grill, hiking, home, marker, route, sings
+      icon: "route"
 
-    # Metas for the event
-    metas:
-      # Email addresses to send registration to
-      # The mail_handles has to be modified in metas.php
-      # More information about this found in chapter "metas.php" down below
-      - "michi"
-      - "josef"
+      # Metas for the event
+      metas:
+        # Email addresses to send registration to
+        # The mail_handles has to be modified in metas.php
+        # More information about this found in chapter "metas.php" down below
+        - "michi"
+        - "josef"
 ```
+
+One can also supply a `categories` element at the root of the yaml structure. Categories are usable as a mixture of tags and filters.
+
+```yaml
+categories:
+  ERSTI:
+    name: i18n:cat_ersti
+    color_fg: "#000000"
+    color_bg: "#ffff00"
+    ribbon: false
+  FSI: 
+    name: i18n:cat_fsi
+    color_fg: "#ffffff"
+    color_bg: "#000080"
+    ribbon: false
+  FSK:
+    name: i18n:cat_fsk
+    color_fg: "#ffffff"
+    color_bg: "#008000"
+    ribbon: false
+  FBI:
+    name: i18n:cat_fbi
+    color_fg: "#000000"
+    color_bg: "#a51e37"
+    ribbon: true
+```
+
+These categories can be referenced at the events structure like this:
+
+```yaml
+  CHF:
+    location: "Clubhaus"
+    location_maps:
+      google: "https://maps.app.goo.gl/JJQ3JjY8SY6vm5em7"
+    registration_enabled: false
+    opentoall : true
+    event_date:
+      start: "30.04.2026 21:00"
+      onTime: false
+    icon: "party"
+    categories:
+      - FSI
+      - FSK
+      - ERSTI
+```
+
+It is possible to add any number of categories to an event. Zero categories are also allowed.
+
 
 ### `metas.php`
 

--- a/category_type.php
+++ b/category_type.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Category type
+ *
+ * This file contains the Event class which represents an event.
+ * It also contains the events array which contains all events.
+ *
+ * To use this file, include it in your PHP file:
+ * require_once "event_type.php";
+ * global $events;
+ */
+
+// Import config because it needs $fp
+require_once "config.php";
+require_once "i18n/i18n.php";
+// Load the Spyc library
+require_once __DIR__ . '/lib/spyc/Spyc.php';
+
+
+global $fp;
+
+/**
+ * Represents a Category.
+ */
+class Category
+{
+	public string $link;
+	public string $name;
+	public string $color_fg;
+	public string $color_bg;
+	public bool $ribbon;
+
+	public function __construct(array $data)
+	{
+		global $i18n;
+		$this->link = $data['link'];
+		$this->name = Category::i18n($data, 'name') ?? $i18n->translate(strtolower($this->link) . '_name') ?? '';
+		$this->color_fg = $data["color_fg"];
+		$this->color_bg = $data["color_bg"];
+		$this->ribbon = $data["ribbon"];
+	}
+
+	private static function i18n(array $data, string $key)
+	{
+		global $i18n;
+
+		// Check if the key exists in the data array
+		if (!isset($data[$key])) {
+			return NULL;
+		}
+		$value = $data[$key];
+		if ($i18n::isI18nKey($value)) {
+			return $i18n->translate($value);
+		}
+		return $value;
+	}
+
+	public static function fromYaml(string $filepath): array
+	{
+		// Load all events from the events.yaml file and initialize the $events array
+		$events = spyc_load_file($filepath);
+		$categories = $events['categories'] ?? [];
+		// Get keys of the events array
+		$keys = array_keys($categories);
+		// Create an array of Event objects where the link is the key of the event
+		$category_map = [];
+		for ($i = 0; $i < count($categories); $i++) {
+			$category = $categories[$keys[$i]];
+			$category['link'] = $keys[$i];
+			$category_map[$keys[$i]] = new Category($category);
+		}
+		$categories = $category_map;
+
+		return $categories;
+	}
+
+}
+
+// Load the categories from the events.yaml file
+// The categories must be imported using the following code:
+// global $events;
+$categories = Category::fromYaml(__DIR__ . '/events.yml');

--- a/css/style.css
+++ b/css/style.css
@@ -530,8 +530,50 @@ form .text-block {
 
 
 
-.language-switcher {
+.category-switcher {
+    text-align: center;
+    position: relative;
+    display: inline-block;
+}
 
+.category-switcher select {
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    padding: 8px 32px 8px 12px;
+    font-size: 16px;
+    border: 1px solid var(--primary-color);
+    border-radius: var(--pill-border-radius);
+    background-color: white;
+    cursor: pointer;
+    min-width: 140px;
+    transition: all 0.2s ease;
+}
+
+.category-switcher::after {
+    content: '▼';
+    font-size: 12px;
+    color: #666;
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+}
+
+.category-switcher select:hover {
+    border-color: #999;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.category-switcher select:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: var(--box-shadow);
+}
+
+
+.language-switcher {
     margin: 20px auto;
     text-align: center;
     position: relative;

--- a/css/style.css
+++ b/css/style.css
@@ -106,6 +106,61 @@ a .link:hover {
 }
 
 
+
+.category-pill-container {
+    display: flex;
+    flex-direction: row;
+    margin: 0px auto;
+    align-items: center;
+    gap: 10px;
+    width: fit-content;
+}
+
+.category-pill {
+    --fg: attr(data-color-fg type(<color>), #ffffff);
+    --bg: attr(data-color-bg type(<color>), #000080);
+    display: inline;
+    background-color: var(--bg);
+    color: var(--fg) !important;
+    border: 1px solid var(--fg);
+    border-radius: var(--pill-border-radius);
+    padding: 6px 12px;
+    font-size: 80%;
+}
+
+.event-info-pill {
+    position: relative;
+    overflow: visible;
+}
+
+.event-ribbons {
+    position: absolute;
+    top: 0;
+    right: 48px;
+    transform: translateY(5px);
+    display: flex;
+    gap: 5px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    max-width: 70%;
+    z-index: 3;
+}
+
+.event-ribbon {
+    --fg: attr(data-color-fg type(<color>), #ffffff);
+    --bg: attr(data-color-bg type(<color>), #000080);
+    background-color: var(--bg);
+    position: relative;
+    padding: 6px 6px;
+    font-size: 0.72rem;
+    font-weight: 700;
+    line-height: 1;
+    border-radius: 6px 6px 6px 6px;
+    box-shadow: 0 2px 6px rgb(0 0 0 / 0.42);
+    white-space: nowrap;
+}
+
+
 .event-link {
     text-decoration: none;
     color: inherit;
@@ -238,6 +293,10 @@ a .link:hover {
     main {
         padding: 15px;
     }
+
+    .event-ribbons {
+        right: 8px;
+    }
 }
 
 @media only screen and (max-width: 320px) {
@@ -251,6 +310,10 @@ a .link:hover {
 
     .event-name {
         margin-right: 0;
+    }
+
+    .event-ribbons {
+        right: 8px;
     }
 }
 
@@ -402,6 +465,10 @@ form .text-block {
     h1 {
         font-size: 1.5em;
     }
+
+    .event-ribbons {
+        right: 8px;
+    }
 }
 
 
@@ -533,4 +600,3 @@ form .text-block {
     background-repeat: no-repeat;
     background-position: center;
 }
-

--- a/event.php
+++ b/event.php
@@ -116,10 +116,10 @@ function renderPage($event, $registrationId)
 				<?php endif; ?>
             </div>
 
-				<?php renderCategories($event) ?>
+			<?php renderCategories($event) ?>
 			<?php
 			if ($event->isOpentoall()) {
-				renderOpentoallNotice($event);
+				//renderOpentoallNotice($event);
 			} ?>
 
         </div>

--- a/event.php
+++ b/event.php
@@ -3,6 +3,7 @@ require_once 'config.php';
 require_once 'utils.php';
 require_once 'i18n/i18n.php';
 require_once 'event_type.php';
+require_once 'category_type.php';
 
 global $i18n, $events, $CONFIG_TERM, $FILE_REVISION, $CONFIG_CONTACT;
 
@@ -115,6 +116,7 @@ function renderPage($event, $registrationId)
 				<?php endif; ?>
             </div>
 
+				<?php renderCategories($event) ?>
 			<?php
 			if ($event->isOpentoall()) {
 				renderOpentoallNotice($event);
@@ -151,6 +153,7 @@ function renderPage($event, $registrationId)
 			<?php
 			endif; ?>
         </div>
+
         <div class="block">
 			<?php
 			if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -409,6 +412,14 @@ function renderOpentoallNotice($event): void
 	<?php
 }
 
+function renderCategories($event): void {
+	global $categories;
+	echo "<div class='category-pill-container'>";
+	foreach($event->categories ?? [] as $category) {
+		echo "<span class='category-pill' data-color-fg='{$category->color_fg}' data-color-bg='{$category->color_bg}'>{$category->name}</span>";
+	}
+	echo "</div>";
+}
 
 function renderErrorMessages($event): void
 {

--- a/event_type.php
+++ b/event_type.php
@@ -13,9 +13,11 @@
 // Import config because it needs $fp
 require_once "config.php";
 require_once "i18n/i18n.php";
+// This type instanciates Category
+require_once 'category_type.php';
 
 // Load the Spyc library
-require __DIR__ . '/lib/spyc/Spyc.php';
+require_once __DIR__ . '/lib/spyc/Spyc.php';
 
 // Metas contains email addresses of people who should be notified when someone registers for an event
 if (file_exists(__DIR__ . '/metas.php')) {
@@ -48,10 +50,11 @@ class Event
 	public string $csvPath;
 	public string $icon;
 	public array $metas;
+	public array $categories;
 
 	public function __construct(array $data)
 	{
-		global $i18n;
+		global $i18n, $categories;
 
 		$this->link = $data['link'];
 		// If the name is set, use it, otherwise use the translation
@@ -89,6 +92,10 @@ class Event
 			$this->csvPath = $data['csv_path'];
 		}
 		$this->metas = $data['metas'] ?? [];
+		// read categories from yaml
+		foreach($data['categories'] ?? [] as $category_name) {
+			$this->categories[] = $categories[$category_name];
+		}
 		$this->icon = $data['icon'];
 	}
 

--- a/events.yml
+++ b/events.yml
@@ -1,3 +1,25 @@
+categories:
+  ERSTI:
+    name: i18n:cat_ersti
+    color_fg: "#000000"
+    color_bg: "#ffff00"
+    ribbon: false
+  FSI: 
+    name: i18n:cat_fsi
+    color_fg: "#ffffff"
+    color_bg: "#000080"
+    ribbon: false
+  FSK:
+    name: i18n:cat_fsk
+    color_fg: "#ffffff"
+    color_bg: "#008000"
+    ribbon: false
+  FBI:
+    name: i18n:cat_fbi
+    color_fg: "#000000"
+    color_bg: "#a51e37"
+    ribbon: true
+
 events:
   ##############################
   ###    FB  Ersti-Events    ###
@@ -15,6 +37,10 @@ events:
       start: "30.04.2026 21:00"
       onTime: false
     icon: "party"
+    categories:
+      - FSI
+      - FSK
+      - ERSTI
 
   MASTERCAFE:
     location: "Maria-von-Linden-Straße 1"
@@ -26,6 +52,9 @@ events:
       start: "09.04.2026 14:30"
       onTime: true
     icon: "information"
+    categories:
+      - FBI
+      - ERSTI
 
   TERMOPEN:
     location: "Maria-von-Linden-Straße 1"
@@ -37,6 +66,8 @@ events:
       start: "10.04.2026 16:15"
       onTime: true
     icon: "information"
+    categories:
+      - FBI
 
   SUBINTRO:
     location: "Various"
@@ -46,6 +77,9 @@ events:
       start: "09.04.2026 16:15"
       onTime: false
     icon: "information"
+    categories:
+      - FBI
+      - ERSTI
 
   ##############################
   ###    FSI Ersti-Events    ###
@@ -67,6 +101,9 @@ events:
     dinos: true
     metas:
       - "kai"
+    categories:
+      - FSI
+      - ERSTI
 
   SP1:
     name: i18n:sp1_name
@@ -87,6 +124,9 @@ events:
     dinos: false
     metas:
       - "matti"
+    categories:
+      - FSI
+      - ERSTI
 
   FRUEHSAND:
     location: "Sand A104"
@@ -105,6 +145,9 @@ events:
     metas:
       - "seb"
       - "kai"
+    categories:
+      - FSI
+      - ERSTI
 
 
   GR2:
@@ -124,6 +167,9 @@ events:
     dinos: true
     metas:
       - "kai"
+    categories:
+      - FSI
+      - ERSTI
 
   WD1:
     location: "Neckarinsel"
@@ -142,6 +188,9 @@ events:
     dinos: true
     metas:
      - "kai"
+    categories:
+      - FSI
+      - ERSTI
 
   SP2:
     name: "i18n:sp2_name"
@@ -162,6 +211,9 @@ events:
     dinos: false
     metas:
       - "matti"
+    categories:
+      - FSI
+      - ERSTI
 
 
   KT1:
@@ -183,6 +235,9 @@ events:
     metas:
       - "seb"
       - "luis"
+    categories:
+      - FSI
+      - ERSTI
 
   WD2:
     location: "Neckarinsel"
@@ -202,6 +257,9 @@ events:
     dinos: true
     metas:
      - "kai"
+    categories:
+      - FSI
+      - ERSTI
 
   FSI_SCHNUSI:
     location: "Sand A104"
@@ -217,6 +275,9 @@ events:
     icon: "cap"
     metas:
       - "seb"
+    categories:
+      - FSI
+      - ERSTI
 
   # FB:
   #   name: "Flunkyball"

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -115,6 +115,8 @@
     "fsi_schnusi_name": "FSI Schnuppersitzung",
     "fsi_schnusi_text": "Du hast Spaß an unseren Ersti-Veranstaltungen gehabt? Du interessierst Dich dafür, was wir sonst noch machen? Und am Wichtigsten: Du möchtest gerne mit anpacken?<br/>Dann komm zu unserer Schnuppersitzung! Dort bekommst du einen Überblick, wie wir arbeiten und wie eine Sitzung funktioniert. Und im Anschluss gibt es eine Pizza-Party mit dem fachschaftseigenen Pizzaofen. Wir stellen den Teig und Tomatensauce (deshalb die Anmeldung), den Belag musst Du Dir selber mitbringen.<br/><br/>Das ist die Schnuppersitzung der Fachschaft Informatik (FSI), d.h. für Studierende der Studiengänge Informatik (B.Sc + B.Ed.), Bioinformatik, Medieninformatik, Medizininformatik und Machine Learning. Studierende der Kognitionswissenschaft schauen bitte bei der Fachschaft Kognitionswissenschaft.",
     "opentoall": "Die Anmeldung ist optional. Jeder ist willkommen!",
+    "category_filter_title": "Events filtern",
+    "category_filter_reset": "Filter löschen",
     "cat_ersti": "Erstis",
     "cat_fsi": "Info",
     "cat_fsk": "Kogni",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -114,5 +114,9 @@
     "dinos": "Dinos willkommen!",
     "fsi_schnusi_name": "FSI Schnuppersitzung",
     "fsi_schnusi_text": "Du hast Spaß an unseren Ersti-Veranstaltungen gehabt? Du interessierst Dich dafür, was wir sonst noch machen? Und am Wichtigsten: Du möchtest gerne mit anpacken?<br/>Dann komm zu unserer Schnuppersitzung! Dort bekommst du einen Überblick, wie wir arbeiten und wie eine Sitzung funktioniert. Und im Anschluss gibt es eine Pizza-Party mit dem fachschaftseigenen Pizzaofen. Wir stellen den Teig und Tomatensauce (deshalb die Anmeldung), den Belag musst Du Dir selber mitbringen.<br/><br/>Das ist die Schnuppersitzung der Fachschaft Informatik (FSI), d.h. für Studierende der Studiengänge Informatik (B.Sc + B.Ed.), Bioinformatik, Medieninformatik, Medizininformatik und Machine Learning. Studierende der Kognitionswissenschaft schauen bitte bei der Fachschaft Kognitionswissenschaft.",
-    "opentoall": "Die Anmeldung ist optional. Jeder ist willkommen!"
+    "opentoall": "Die Anmeldung ist optional. Jeder ist willkommen!",
+    "cat_ersti": "Erstis",
+    "cat_fsi": "Info",
+    "cat_fsk": "Kogni",
+    "cat_fbi": "Fachbereich"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -114,5 +114,9 @@
   "dinos": "Dinos welcome!",
   "fsi_schnusi_name": "FSI Introductory Session",
   "fsi_schnusi_text": "Did you enjoy our freshmen events? Are you interested in what else we do? And most importantly: Would you like to get involved?<br/>Then come to our introductory session! There you'll get an overview of how we work and how a session works. Afterwards, there will be a pizza party with the student council's own pizza oven. We'll provide the dough and tomato sauce (hence the registration), but you'll need to bring your own toppings.<br/><br/>This is the introductory session of the Computer Science Student Council (FSI), i.e., for students of Computer Science (B.Sc. + B.Ed.), Bioinformatics, Media Informatics, Medical Informatics, and Machine Learning. Cognitive Science students, please see the Fachschaft Kognitionswissenschaft.",
-  "opentoall": "Registration is optional. Just come by!"
+  "opentoall": "Registration is optional. Just come by!",
+  "cat_ersti": "starters",
+  "cat_fsi": "computer science",
+  "cat_fsk": "cognitive science",
+  "cat_fbi": "cs department"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -115,8 +115,8 @@
   "fsi_schnusi_name": "FSI Introductory Session",
   "fsi_schnusi_text": "Did you enjoy our freshmen events? Are you interested in what else we do? And most importantly: Would you like to get involved?<br/>Then come to our introductory session! There you'll get an overview of how we work and how a session works. Afterwards, there will be a pizza party with the student council's own pizza oven. We'll provide the dough and tomato sauce (hence the registration), but you'll need to bring your own toppings.<br/><br/>This is the introductory session of the Computer Science Student Council (FSI), i.e., for students of Computer Science (B.Sc. + B.Ed.), Bioinformatics, Media Informatics, Medical Informatics, and Machine Learning. Cognitive Science students, please see the Fachschaft Kognitionswissenschaft.",
   "opentoall": "Registration is optional. Just come by!",
-  "cat_ersti": "starters",
-  "cat_fsi": "computer science",
-  "cat_fsk": "cognitive science",
-  "cat_fbi": "cs department"
+  "cat_ersti": "Starters",
+  "cat_fsi": "Computer Science",
+  "cat_fsk": "Cognitive Science",
+  "cat_fbi": "CS Department"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -115,6 +115,8 @@
   "fsi_schnusi_name": "FSI Introductory Session",
   "fsi_schnusi_text": "Did you enjoy our freshmen events? Are you interested in what else we do? And most importantly: Would you like to get involved?<br/>Then come to our introductory session! There you'll get an overview of how we work and how a session works. Afterwards, there will be a pizza party with the student council's own pizza oven. We'll provide the dough and tomato sauce (hence the registration), but you'll need to bring your own toppings.<br/><br/>This is the introductory session of the Computer Science Student Council (FSI), i.e., for students of Computer Science (B.Sc. + B.Ed.), Bioinformatics, Media Informatics, Medical Informatics, and Machine Learning. Cognitive Science students, please see the Fachschaft Kognitionswissenschaft.",
   "opentoall": "Registration is optional. Just come by!",
+  "category_filter_title": "filter events",
+  "category_filter_reset": "reset filter",
   "cat_ersti": "Starters",
   "cat_fsi": "Computer Science",
   "cat_fsk": "Cognitive Science",

--- a/index.php
+++ b/index.php
@@ -41,14 +41,28 @@ require_once 'head.php';
         <!-- category chooser bar -->
         <div class="category-pill-container">
         <?php if(empty($_GET["cat"])) { ?>
-            <?php foreach($categories ?? [] as $category) { ?>
-                <a class="category-pill"
-                    data-color-fg="<?=$category->color_fg?>"
-                    data-color-bg="<?=$category->color_bg?>"
-                    href="index.php?cat=<?=$category->link?>&lang=<?=$i18n->getLanguage()?>"
-                    >
-                        <?=$category->name?>
-                </a>
+            <?php if(count($categories) > 4) { ?>
+                <div class="category-switcher">
+                    <label for="category-selection" style="display: none;">Category</label> <!-- Hidden label for accessibility -->
+                    <select id="category-selection" aria-label="Select category">
+                        <option selected disabled hidden>Events filtern</option>        
+                    <?php foreach($categories ?? [] as $category) { ?>
+                        <option value="<?=$category->link?>">
+                            <?=$category->name?>
+                        </option>
+                    <?php } ?>
+                    </select>
+                </div>
+            <?php } else { ?>
+                <?php foreach($categories ?? [] as $category) { ?>
+                    <a class="category-pill"
+                        data-color-fg="<?=$category->color_fg?>"
+                        data-color-bg="<?=$category->color_bg?>"
+                        href="index.php?cat=<?=$category->link?>&lang=<?=$i18n->getLanguage()?>"
+                        >
+                            <?=$category->name?>
+                    </a>
+                <?php } ?>
             <?php } ?>
         <?php } else { ?>
                 <a class="category-pill" 
@@ -165,6 +179,14 @@ require_once 'head.php';
         let baseUrl = window.location.protocol + "//" + window.location.host + window.location.pathname;
         // Add the new language parameter
         location.href = `${baseUrl}?lang=${this.value}`;
+    });
+
+    // Category change handler
+    document.getElementById('category-selection').addEventListener('change', function () {
+        // Construct URL without query string first
+        let baseUrl = window.location.protocol + "//" + window.location.host + window.location.pathname;
+        // Add the new category parameter
+        location.href = `${baseUrl}?lang=<?=$i18n->getLanguage()?>&cat=${this.value}`;
     });
 </script>
 <script src="js/calendarModal.js"></script>

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ require_once 'head.php';
                 <div class="category-switcher">
                     <label for="category-selection" style="display: none;">Category</label> <!-- Hidden label for accessibility -->
                     <select id="category-selection" aria-label="Select category">
-                        <option selected disabled hidden>Events filtern</option>        
+                        <option selected disabled hidden><?=$i18n["category_filter_title"]?></option>        
                     <?php foreach($categories ?? [] as $category) { ?>
                         <option value="<?=$category->link?>">
                             <?=$category->name?>
@@ -70,7 +70,7 @@ require_once 'head.php';
                     data-color-bg="<?=$categories[$_GET["cat"]]->color_bg?>">
                     <?=$categories[$_GET["cat"]]->name?>
                 </a>
-                <a class="category-pill" href="index.php?lang=<?=$i18n->getLanguage()?>">Filter löschen</a>
+                <a class="category-pill" href="index.php?lang=<?=$i18n->getLanguage()?>"><?=$i18n["category_filter_reset"]?></a>
         <?php } ?>
         </div>
 

--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@ require_once 'utils.php';
 require_once 'event_type.php';
 require_once 'i18n/i18n.php';
 
-global $i18n, $CONFIG_TERM, $FILE_REVISION, $events;
+global $i18n, $CONFIG_TERM, $FILE_REVISION, $events, $categories;
 
 // Load environment variables from the .env file
 loadEnv('.env');
@@ -37,6 +37,32 @@ require_once 'head.php';
                 <option value="en" <?= $i18n->getLanguage() === 'en' ? 'selected' : '' ?>>🇬🇧 English</option>
             </select>
         </div>
+
+        <!-- category chooser bar -->
+        <div class="category-pill-container">
+        <?php if(empty($_GET["cat"])) { ?>
+            <?php foreach($categories ?? [] as $category) { ?>
+                <a class="category-pill"
+                    data-color-fg="<?=$category->color_fg?>"
+                    data-color-bg="<?=$category->color_bg?>"
+                    href="index.php?cat=<?=$category->link?>&lang=<?=$i18n->getLanguage()?>"
+                    >
+                        <?=$category->name?>
+                </a>
+            <?php } ?>
+        <?php } else { ?>
+                <a class="category-pill" 
+                    data-color-fg="<?=$categories[$_GET["cat"]]->color_fg?>"
+                    data-color-bg="<?=$categories[$_GET["cat"]]->color_bg?>">
+                    <?=$categories[$_GET["cat"]]->name?>
+                </a>
+                <a class="category-pill" href="index.php?lang=<?=$i18n->getLanguage()?>">Filter löschen</a>
+        <?php } ?>
+        </div>
+
+
+
+
     </div>
 
     <div class="container">
@@ -54,6 +80,17 @@ require_once 'head.php';
             return $a->getEventStartUTS() - $b->getEventStartUTS();
         });
 
+        // filter by category if set
+        if(!empty($_GET["cat"])) {
+            $sorted_events = array_filter(
+                $sorted_events,
+                fn($e) => count(array_filter(
+                    $e->categories,
+                    fn($cat) => ($cat->link ?? null) === $_GET["cat"]
+                )) > 0
+            );
+        }
+
         // Render the sorted events
         foreach ($sorted_events as $event) {
             ?>
@@ -63,6 +100,15 @@ require_once 'head.php';
                         <?= $event->getEventDateString(['compact' => true, 'no_time' => true]) ?>
                     </div>
                     <div class="event-pill event-info-pill">
+                        <div class="event-ribbons">
+                        <?php foreach($event->categories ?? [] as $category) { 
+                                if( ! $category->ribbon) continue ?>
+                            <span class="event-ribbon" 
+                                data-color-fg='<?=$category->color_fg?>' 
+                                data-color-bg='<?=$category->color_bg?>'>
+                            </span>
+                        <?php } ?>
+                        </div>
                         <span class="event-name"><?= htmlspecialchars($event->name) ?></span>
                         <?php
                         // Render icon using a span and the class from $event->icon ?>


### PR DESCRIPTION
This PR contains a event category extension for the EEI as mentioned in issue #267.

One can now:
- Supply categories with the `events.yml` file with options like name, color and a flag to show indicators/ribbons
- Reference these categories in the events structure to put an event into a category
- Filter over this categories at the main page of the EEI

For now, it looks like this...

<img width="741" height="1185" alt="image" src="https://github.com/user-attachments/assets/ad68c3b0-4cfc-46c3-a5db-c4319580f12b" />

... or this...
<img width="712" height="1208" alt="image" src="https://github.com/user-attachments/assets/2cc37ef0-af0f-45df-8bc5-5a6ab0263552" />

... or this (collapsed filter control if there are more than 4 categories):
<img width="536" height="368" alt="image" src="https://github.com/user-attachments/assets/d6071bcd-b064-49f8-be92-8118ddc1fea3" />

The underlying code works well, even if I wrote it in the usual EEI style. But I am definitely *not* a web designer, so maybe someone else can make this PR look a bit nicer. :D